### PR TITLE
WIP unboxing and reboxing implementation

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -3,7 +3,13 @@ module Main where
 import Graphics.Element exposing (show)
 import Table
 
+type UnboxableType = Unbox Int | Other Int
+
 main = show
-    <| Table.get 1
-    <| Table.indexedMap (\i v -> i + 1)
-    <| Table.fromList [1, 2, 3]
+    <| Table.update 1
+        (\o ->
+            case o of
+                Unbox v -> Other <| v + 1
+                Other v -> Unbox <| v + 2
+        )
+    <| Table.fromList [Unbox 1, Unbox 2, Unbox 3]

--- a/src/Native/Table.js
+++ b/src/Native/Table.js
@@ -33,6 +33,7 @@ var make = function make(elm) {
         return i;
     }
 
+    // check if all items have the same ctor
     var allSameCtors = function(items){
         var ctor = items[0].ctor;
 
@@ -49,6 +50,7 @@ var make = function make(elm) {
         return true;
     };
 
+    // check if item is an Elm value with only one prop
     var onlyHasSingleValue = function(item){
         return Object.keys(item).length < 3;
     };
@@ -70,6 +72,14 @@ var make = function make(elm) {
         return true;
     };
 
+    /* Create a new table unwrapping Elm values
+
+        values = [Age 5, Age 6, Age 7], valueCtor = Nothing
+
+        becomes
+
+        values = [ 5, 6, 7 ], valueCtor = Just Age
+    */
     var unbox = function(table){
         table.valueCtor = Maybe.Just(table.values[0].ctor);
 
@@ -84,6 +94,10 @@ var make = function make(elm) {
         return table;
     };
 
+    /*
+        use the provided table to figure out
+        the unboxed representation of a value
+    */
     var unboxOne = function(v, table){
         var maybeCtor = table.valueCtor;
         if (maybeCtor === Maybe.Nothing){
@@ -93,6 +107,10 @@ var make = function make(elm) {
         return v._0;
     };
 
+    /*
+        return true if given value needs reboxing to
+        fit into the given table
+    */
     var needsReboxing = function(v, table){
         if (table.valueCtor === Maybe.Nothing){
             return false;
@@ -100,6 +118,9 @@ var make = function make(elm) {
         return v.ctor !== table.valueCtor._0;
     };
 
+    /*
+        Inverse of unbox
+    */
     var rebox = function(table){
         var maybeCtor = table.valueCtor;
         if (maybeCtor === Maybe.Nothing){

--- a/src/Table.elm
+++ b/src/Table.elm
@@ -63,6 +63,10 @@ get : Int -> Table a -> Maybe a
 get =
   Native.Table.get
 
-update : List (Int, a -> a) -> Table a -> Table a
+update : Int -> (a -> b) -> Table a -> Table a
 update =
   Native.Table.update
+
+updateMany : List (Int, a -> a) -> Table a -> Table a
+updateMany =
+  Native.Table.updateMany


### PR DESCRIPTION
I haven't decided if this is a good idea yet.

tl;dr:
- Storing Elm values (those with `ctor`) in an array has much smaller performance + size benefits over those without
- Unboxing allows us to pull out the JS value from an Elm value
- Reboxing allows us to use the API seeminglessly _without the end developer needing to worry about performance benefits_
## Caveats
- Currently only works for items with a single arg, e.g `Unbox Int` will be unboxed but `Unbox Int Int` won't
